### PR TITLE
use ld.shared.v4.f32 for Rmem and Double buffered Implementations

### DIFF
--- a/nvidia/bench/bench_double_buffered_128x128x64_16x4x1_f32f32f32.cu
+++ b/nvidia/bench/bench_double_buffered_128x128x64_16x4x1_f32f32f32.cu
@@ -12,7 +12,7 @@ int main() {
 
   constexpr int TM = 16;
   constexpr int TN = 4;
-  constexpr int TK = 1;
+  constexpr int TK = 4;
 
   float alpha = 1.0f;
   float beta = 1.0f;

--- a/nvidia/bench/bench_rmem_64x128x128_2x4x4_f32f32f32.cu
+++ b/nvidia/bench/bench_rmem_64x128x128_2x4x4_f32f32f32.cu
@@ -12,7 +12,7 @@ int main() {
 
   constexpr int TM = 16;
   constexpr int TN = 4;
-  constexpr int TK = 2;
+  constexpr int TK = 4;
 
   float alpha = 1.0f;
   float beta = 1.0f;

--- a/nvidia/kernels/double_buffered_gemm.cuh
+++ b/nvidia/kernels/double_buffered_gemm.cuh
@@ -111,9 +111,12 @@ __launch_bounds__(BlockDim) __global__
           for (int k_thread = 0; k_thread < TK; k_thread++) {
             asm volatile(
                 "{\n\t"
-                "ld.shared.f32 %0, [%1]; \n"
+                "ld.shared.v4.f32 {%0, %1, %2, %3}, [%4]; \n"
                 "}"
-                : "=f"(RmemA[mm * TK + k_thread])
+                : "=f"(RmemA[mm * TK + k_thread + 0]),
+                  "=f"(RmemA[mm * TK + k_thread + 1]),
+                  "=f"(RmemA[mm * TK + k_thread + 2]),
+                  "=f"(RmemA[mm * TK + k_thread + 3])
                 : "r"(smem_a_k_addr +
                       (smem_row_offset + k_thread) * sizeof_TIn));
           }

--- a/nvidia/kernels/rmem_tiled_gemm.cuh
+++ b/nvidia/kernels/rmem_tiled_gemm.cuh
@@ -97,13 +97,15 @@ __launch_bounds__(BlockDim) __global__
         for (int mm = 0; mm < TM; mm++) {
           auto smem_row_offset = (warp_id * TM + mm) * K + inner;
 #pragma unroll
-          for (int k_thread = 0; k_thread < TK; k_thread += 2) {
+          for (int k_thread = 0; k_thread < TK; k_thread += 4) {
             asm volatile(
                 "{\n\t"
-                "ld.shared.v2.f32 {%0, %1}, [%2]; \n"
+                "ld.shared.v4.f32 {%0, %1, %2, %3}, [%4]; \n"
                 "}"
                 : "=f"(RmemA[mm * TK + k_thread + 0]),
-                  "=f"(RmemA[mm * TK + k_thread + 1])
+                  "=f"(RmemA[mm * TK + k_thread + 1]),
+                  "=f"(RmemA[mm * TK + k_thread + 2]),
+                  "=f"(RmemA[mm * TK + k_thread + 3])
                 : "r"(smem_a_addr + (smem_row_offset + k_thread) * sizeof_TIn));
           }
         }


### PR DESCRIPTION
Smem A loads were erroneously not using ld.global.v4.f32. This PR fixes the same.
This enable 16 * 4 * 4 = 256 FFMAs for 16 + 4  = 20 loads from shared memory.