### PR TITLE
remove ring buffer usage from double_buffered_gemm

### DIFF
--- a/nvidia/kernels/double_buffered_gemm.cuh
+++ b/nvidia/kernels/double_buffered_gemm.cuh
@@ -30,10 +30,6 @@ __launch_bounds__(BlockDim) __global__
   int32_t smem_b_addr = smem_a_addr + M * K * sizeof_TIn * NumBuffers;
   const int32_t SmemABufferSize = M * K * sizeof_TIn;
   const int32_t SmemBBufferSize = K * N * sizeof_TIn;
-  ring_buffer::smem_ring_buffer<NumBuffers, SmemABufferSize> smem_a_buffer(
-      smem_a_addr);
-  ring_buffer::smem_ring_buffer<NumBuffers, SmemBBufferSize> smem_b_buffer(
-      smem_b_addr);
 
   int block_id = blockIdx.x;
   int warp_id = threadIdx.x / 32;
@@ -58,11 +54,12 @@ __launch_bounds__(BlockDim) __global__
 
     auto tile_row_start = block_id / N_tiles;
     auto tile_col_start = block_id % N_tiles;
+    int32_t buffer_index = 0;
 
     // just hardcoded for now
     for (int kk = 0; kk < k; kk += K) {
-      auto smem_a_k_addr = smem_a_buffer.get_current_buffer();
-      auto smem_b_k_addr = smem_b_buffer.get_current_buffer();
+      auto smem_a_k_addr = smem_a_addr + buffer_index * M * K * sizeof_TIn;
+      auto smem_b_k_addr = smem_b_addr + buffer_index * K * N * sizeof_TIn;
 
       // Load SmemA tile
       for (int m_warp = warp_id; m_warp < M; m_warp += num_warps) {
@@ -103,6 +100,7 @@ __launch_bounds__(BlockDim) __global__
       }
       __syncthreads();
 
+#pragma unroll
       for (int inner = 0; inner < K; inner += TK) {
 #pragma unroll
         for (int mm = 0; mm < TM; mm++) {
@@ -154,6 +152,7 @@ __launch_bounds__(BlockDim) __global__
           }
         }
       }
+      buffer_index = (buffer_index + 1) % NumBuffers;
     }
 
 #pragma unroll


### PR DESCRIPTION
Usage of `ring_buffer::smem_ring_buffer`  was causing spills to local memory even though the compiler had abundant register budget to avoid the same. I suspect this has something to do with class variable visibility or something to that affect.
Though I would like to make use of the ring buffer class later on as the buffer depth increases with async copies, I have kept the file, but removed it's usage replacing it with a simple index counter for the same. 

difference in performance on a 3060 Max Q:

| Size      | Main |   This PR |
| ----------- | ----------- |---------|
| 1024 x 1024 x 1024      | 2.435 TFlops       |       3.43 TFLops|
| 2048 x 2048 x 2048   | 3.9 TFlops        |      5.538 TFlops|
|4096 x 4096 x 4096    | 3.9 TFLops       |   5.532 TFLops                          |